### PR TITLE
revised payment type delete to check if attached to orders

### DIFF
--- a/models/Payment-Type.js
+++ b/models/Payment-Type.js
@@ -44,9 +44,18 @@ module.exports.dbPutPaymentType = (req, payment_type_id) => {
 
 module.exports.dbDeleteOnePaymentType = (id) => {
   return new Promise((resolve, reject) => {
-    db.run(`DELETE FROM payment_types WHERE id = ${id}`, function(err){
-      if (err) reject(err);
-      resolve({ message: "delete successful", rows_deleted: this.changes });
+    db.all(`SELECT * FROM orders WHERE payment_type_id = ${id}`, (err, data) => {
+      if(err) reject(err);
+      if(data.length === 0)
+      {
+        db.run(`DELETE FROM payment_types WHERE id = ${id}`, function(err) {
+          if(err)
+            reject(err);
+          resolve({message: "delete successful", rows_deleted: this.changes});
+        });
+      }
+      else
+        reject("Cannot delete this Data, It has Orders associated with it");
     });
   });
 };


### PR DESCRIPTION
Related Issue:# 46

Changes:
Revised delete on payment-type to check if there is an order attached first

Readme Info:
 - [ ] required packages (new)
 - [ ] API instructions

Any other Testing Steps:
DELETE "/payment-types/:id" (make sure to check that payment is attached to an order first to verify the error)
