### PR TITLE
Db orders jr

### DIFF
--- a/db/build-db.js
+++ b/db/build-db.js
@@ -16,6 +16,7 @@ const { generateOrders } = require('./faker/orders');
 const { generateComputers } = require('./faker/computers');
 const { generateEmployeeTrainings } = require('./faker/employeeTrainings');
 const { generateEmployeeComputers } = require('./faker/employeeComputers');
+const { generateOrderProducts } = require('./faker/orderProducts');
 
 // generate arrays of simulated data
 let productTypes = generateTypes();
@@ -27,8 +28,9 @@ let employees = generateEmployees();
 let departments = generateDepartments();
 let trainingPrograms = generateTrainingPrograms();
 let computers = generateComputers();
-let employeeTrainings = generateEmployeeTrainings(trainingPrograms); // pass trainingPrograms array into join table generation
+let employeeTrainings = generateEmployeeTrainings(trainingPrograms); // pass trainingPrograms array into join table generation for max attendance per
 let employeeComputers = generateEmployeeComputers();
+let orderProducts = generateOrderProducts();
 
 // one db.serialize to avoid table creation conflicts
 db.serialize(function () {
@@ -240,22 +242,10 @@ db.serialize(function () {
           FOREIGN KEY(order_id) REFERENCES orders(id) ON DELETE CASCADE)`
   );
 
-  const { amounts: { maxQuantity, maxProductsPerOrder } } = require('./faker/generatorAmounts.json');
-  orders.forEach((order, index) => {
-    let order_id = index + 1;
-    // randomize the number of products per order up to max
-    let numProducts = Math.floor(Math.random() * maxProductsPerOrder) + 1;
-    for (let j = 0; j < numProducts; j++) {
-      // choose one product out of the total number of products
-      let randomProduct = Math.floor(Math.random() * products.length) + 1;
-      // randomize the quantity ordered between 1 and an upper limit, from generatorAmounts.json
-      let qty = Math.floor(Math.random() * maxQuantity) + 1;
-      for (let i = 0; i < qty; i++) {
-        db.run(`INSERT INTO ordersProducts (product_id, order_id)
-        VALUES('${randomProduct}', ${order_id})`
-        );
-      }
-    }
+  orderProducts.forEach(({ product_id, order_id }) => {
+    db.run(`INSERT INTO ordersProducts (product_id, order_id)
+      VALUES('${product_id}', ${order_id})`
+    );
   });
 
 });

--- a/db/build-db.js
+++ b/db/build-db.js
@@ -240,18 +240,21 @@ db.serialize(function () {
           FOREIGN KEY(order_id) REFERENCES orders(id) ON DELETE CASCADE)`
   );
 
-  const { amounts: { maxQuantity } } = require('./faker/generatorAmounts.json');
+  const { amounts: { maxQuantity, maxProductsPerOrder } } = require('./faker/generatorAmounts.json');
   orders.forEach((order, index) => {
     let order_id = index + 1;
-    // TODO - randomize the number of products per order - currently one a piece
-    // choose one product out of the total number of products
-    let randomProduct = Math.floor(Math.random() * products.length) + 1;
-    // randomize the quantity ordered between 1 and an upper limit, from generatorAmounts.json
-    let qty = Math.floor(Math.random() * maxQuantity) + 1;
-    for (let i = 0; i < qty; i++) {
-      db.run(`INSERT INTO ordersProducts (product_id, order_id)
-            VALUES('${randomProduct}', ${order_id})`
-      );
+    // randomize the number of products per order up to max
+    let numProducts = Math.floor(Math.random() * maxProductsPerOrder) + 1;
+    for (let j = 0; j < numProducts; j++) {
+      // choose one product out of the total number of products
+      let randomProduct = Math.floor(Math.random() * products.length) + 1;
+      // randomize the quantity ordered between 1 and an upper limit, from generatorAmounts.json
+      let qty = Math.floor(Math.random() * maxQuantity) + 1;
+      for (let i = 0; i < qty; i++) {
+        db.run(`INSERT INTO ordersProducts (product_id, order_id)
+        VALUES('${randomProduct}', ${order_id})`
+        );
+      }
     }
   });
 

--- a/db/faker/employeeTrainings.js
+++ b/db/faker/employeeTrainings.js
@@ -1,8 +1,6 @@
 'use strict';
-// using Faker to generate a some departments
-const faker = require('faker');
 
-const { amounts: {numEmployees, numTrainingPrograms}} = require('./generatorAmounts.json');
+const { amounts: { numEmployees, numTrainingPrograms } } = require('./generatorAmounts.json');
 
 module.exports.generateEmployeeTrainings = (trainingProgramsArray) => {
 
@@ -10,10 +8,10 @@ module.exports.generateEmployeeTrainings = (trainingProgramsArray) => {
 
   for (let i = 1; i <= numTrainingPrograms; i++) {
 
-    let maxAttendance = trainingProgramsArray[i-1].max_attendance;
+    let maxAttendance = trainingProgramsArray[i - 1].max_attendance;
     let attendance = Math.floor(Math.random() * maxAttendance) + 1;
 
-    for(let j = 0; j < attendance; j++) {
+    for (let j = 0; j < attendance; j++) {
 
       let employee_id = Math.floor(Math.random() * numEmployees) + 1;;
 

--- a/db/faker/generatorAmounts.json
+++ b/db/faker/generatorAmounts.json
@@ -11,6 +11,7 @@
     "numDepartments": 8,
     "numEmployeeTrainings": 25,
     "numEmployeeComputers": 40,
-    "maxQuantity": 10
+    "maxQuantity": 5,
+    "maxProductsPerOrder": 3
   }
 }

--- a/db/faker/generatorAmounts.json
+++ b/db/faker/generatorAmounts.json
@@ -4,7 +4,7 @@
     "numUsers": 20,
     "numComputers": 40,
     "numEmployees": 25,
-    "numOrders": 10,
+    "numOrders": 100,
     "numPaymentTypes": 175,
     "numProducts": 50,
     "numTrainingPrograms": 10,

--- a/db/faker/orderProducts.js
+++ b/db/faker/orderProducts.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { amounts: { maxQuantity, maxProductsPerOrder, numProducts, numOrders } } = require('./generatorAmounts.json');
+
+module.exports.generateOrderProducts = () => {
+
+  let orderProducts = [];
+
+  for (let k = 1; k <= numOrders; k++) {
+    //for each order
+    let order_id = k;
+    // randomize the number of products per order up to max
+    let uniqueProducts = Math.floor(Math.random() * maxProductsPerOrder) + 1;
+    // for each product "slot"
+    for (let j = 0; j < uniqueProducts; j++) {
+      // choose random product out of the total number of products
+      let product_id = Math.floor(Math.random() * numProducts) + 1;
+      // randomize the quantity pushed to array (ordered) between 1 and an upper limit
+      let qty = Math.floor(Math.random() * maxQuantity) + 1;
+      for (let i = 0; i < qty; i++) {
+        orderProducts.push({
+          product_id,
+          order_id,
+        });
+      }
+    }
+  }
+  return orderProducts;
+};

--- a/db/faker/orders.js
+++ b/db/faker/orders.js
@@ -9,8 +9,12 @@ module.exports.generateOrders = () => {
 
   for (let i = 0; i < numOrders; i++) {
     let order_date = faker.date.past().toISOString(); //generates an ISO formate date string
-    let payment_type_id = Math.floor(Math.random() * numPaymentTypes) + 1;
     let customer_user_id = Math.floor(Math.random() * numUsers) + 1;
+    let payment_type_id = null;
+    let closedOrderChance = Math.floor(Math.random() * 100);
+    if (closedOrderChance > 50) {
+      payment_type_id = Math.floor(Math.random() * numPaymentTypes) + 1;
+    }
 
     orders.push({
       order_date,

--- a/db/faker/products.js
+++ b/db/faker/products.js
@@ -9,7 +9,7 @@ module.exports.generateProducts = () => {
 
   for (let i = 0; i < numProducts; i++) {
     let title = faker.commerce.productName();
-    let price = faker.commerce.price();
+    let price = faker.commerce.price() / 10;
     let description = faker.lorem.sentence();
     let type_id = Math.floor(Math.random() * numProductTypes) + 1;
     let seller_user_id = Math.floor(Math.random() * numUsers) + 1;


### PR DESCRIPTION
Related Issue:
DB creation/db:reset
Changes:
-random number of unique products per order
-modularized order product generation, as other tables in build-db
-prices now in $XX.X0 format / $0.00 - 100.00
-50% of orders will be open (no payment type - previously all had payment type)

Readme Info:
none, dev only

Any other Testing Steps:
npm run db:reset, and check db browser
